### PR TITLE
 getShortName refactored 

### DIFF
--- a/core/src/main/java/hudson/ClassicPluginStrategy.java
+++ b/core/src/main/java/hudson/ClassicPluginStrategy.java
@@ -103,13 +103,19 @@ public class ClassicPluginStrategy implements PluginStrategy {
     }
 
     @Override public String getShortName(File archive) throws IOException {
-        Manifest manifest;
+        validateArchive(archive);
+        Manifest manifest = getManifest(archive);
+        return PluginWrapper.computeShortName(manifest, archive.getName());
+    }
+    private static void validateArchive(File archive) throws IOException{
         if (!archive.exists()) {
             throw new FileNotFoundException("Failed to load " + archive + ". The file does not exist");
         } else if (!archive.isFile()) {
             throw new FileNotFoundException("Failed to load " + archive + ". It is not a file");
         }
-
+    }
+    private static Manifest getManifest(File archive) throws IOException{
+        Manifest manifest;
         if (isLinked(archive)) {
             manifest = loadLinkedManifest(archive);
         } else {
@@ -120,7 +126,7 @@ public class ClassicPluginStrategy implements PluginStrategy {
                 throw new IOException("Failed to load " + archive, ex);
             }
         }
-        return PluginWrapper.computeShortName(manifest, archive.getName());
+        return manifest;
     }
 
     private static boolean isLinked(File archive) {


### PR DESCRIPTION
See File [https://github.com/subahm/jenkins/core/src/main/java/hudson/ClassicPlugInStrategy.java]

**Proposed changelog entries**

Entry 1: Issue, bloater - long method. Found in ClassicPlugInStrategy.java

**Proposed upgrade guidelines**

Extracted the getShortName method and created two new methods called "validateArchive" and "getManifest". Code is cleaner, easier to read and getShortName method size has been reduced from 21 lines to 3 lines. Refactored code passes all tests.

**Submitter checklist**

- [x] JIRA issue is well described
- [x] Changelog entries and upgrade guidelines are appropriate for the audience affected by the change (users or developer, depending on the change). Examples
          Fill-in the Proposed changelog entries section only if there are breaking changes or other changes which may require extra steps from users during the upgrade
- [x] Appropriate autotests or explanation to why this change has no tests
- [x]  For dependency updates: links to external changelogs and, if possible, full diffs

**Desired reviewers**

@brookeireland
@hirron
@subahm
@zoegoodwinsutton 
@WhitneyDluhosh

**Maintainer checklist**

Before the changes are marked as ready-for-merge:

- [ ] There are at least 2 approvals for the pull request and no outstanding requests for change
- [x] Conversations in the pull request are over OR it is explicit that a reviewer does not block the change
- [x] Changelog entries in the PR title and/or Proposed changelog entries are correct
- [x] Proper changelog labels are set so that the changelog can be generated automatically